### PR TITLE
parse NAV-TIMEUTC

### DIFF
--- a/src/ubx.erl
+++ b/src/ubx.erl
@@ -69,13 +69,13 @@
                         v_acc => non_neg_integer() %% in MM
                        }.
 -type nav_timeutc() :: #{
-                         year => non_neg_integer(),
-                         month => non_neg_integer(),
-                         day => non_neg_integer(),
-                         hour => non_neg_integer(),
-                         min => non_neg_integer(),
-                         sec => non_neg_integer(),
-                         nano => integer() %% fraction of sec, range -1e9 .. 1e9
+                         datetime => calendar:datetime(),
+                         t_acc => non_neg_integer(), %% time accuracy estimate in ns
+                         nano => integer(), %% fraction of sec, range -1e9 .. 1e9,
+                         utc_std => non_neg_integer(), %% UTC standard identifier
+                         valid_utc => non_neg_integer(), %% 1 = Valid UTC Time
+                         valid_wkn => non_neg_integer(), %% 1 = Valid Week Number
+                         valid_tow => non_neg_integer()  %% 1 = Valid Time of Week
                         }.
 
 -export_type([nav_pvt/0, nav_sat/0, nav_posllh/0, nav_sol/0, nav_timeutc/0, fix_type/0]).
@@ -409,18 +409,18 @@ parse(?NAV, ?SOL, <<_ITOW:?U4, _FTOW:?I4, _Week:?I2, GPSFix:?U1, _/binary>>) ->
     %io:format("SOL ~p~n", [GPSFix]),
     {nav_sol, GPSFix};
 %% UBX-NAV-TIMEUTC
-parse(?NAV, ?TIMEUTC, <<_ITOW:?U4, _TAcc:?U4, Nano:?I4, Year:?U2, Month:?U1, Day:?U1, Hour:?U1, Min:?U1, Sec:?U1, Valid:?X1>>) ->
-    io:format("Time UTC: Year ~p Month ~p Day ~p Hour ~p Min ~p Sec ~p Nano ~p~n", [Year, Month, Day, Hour, Min, Sec, Nano]),
-    <<UTCStandard:4/integer-unsigned-big, _:1/integer, ValidUTC:1/integer, ValidWKN:1/integer, ValidTOW:1/integer>> = <<Valid:8/integer-big>>,
+parse(?NAV, ?TIMEUTC, <<_ITOW:?U4, TAcc:?U4, Nano:?I4, Year:?U2, Month:?U1, Day:?U1, Hour:?U1, Min:?U1, Sec:?U1, Valid:?X1>>) ->
+    io:format("Time UTC: Year ~p Month ~p Day ~p Hour ~p Min ~p Sec ~p TAcc ~p Nano ~p~n", [Year, Month, Day, Hour, Min, Sec, TAcc, Nano]),
+    <<UTCStandard:4/integer-unsigned-big, _:1/integer-unsigned, ValidUTC:1/integer-unsigned, ValidWKN:1/integer-unsigned, ValidTOW:1/integer-unsigned>> = <<Valid:8/integer-big>>,
     io:format("          UTCStandard ~p ValidUTC ~p ValidWKN ~p ValidTOW ~p~n", [UTCStandard, ValidUTC, ValidWKN, ValidTOW]),
     {nav_timeutc, #{
-                    year => Year,
-                    month => Month,
-                    day => Day,
-                    hour => Hour,
-                    min => Min,
-                    sec => Sec,
-                    nano => Nano
+                    datetime => {{Year, Month, Day}, {Hour, Min, Sec}},
+                    t_acc => TAcc,
+                    nano => Nano,
+                    utc_std => UTCStandard,
+                    valid_utc => ValidUTC,
+                    valid_wkn => ValidWKN,
+                    valid_tow => ValidTOW
                    }};
 %% UBX-MON-VER
 parse(?MON, ?VER, <<SWVersion:30/binary, HWVersion:10/binary, Tail/binary>>) ->

--- a/src/ubx.erl
+++ b/src/ubx.erl
@@ -39,6 +39,7 @@
 -define(CFG2, 16#09).
 -define(TP5, 16#31).
 -define(ANT, 16#13).
+-define(TIMEUTC, 16#21).
 
 
 -type fix_type() :: non_neg_integer(). %% gps fix type
@@ -67,8 +68,17 @@
                         h_acc => non_neg_integer(), %% in MM
                         v_acc => non_neg_integer() %% in MM
                        }.
+-type nav_timeutc() :: #{
+                         year => non_neg_integer(),
+                         month => non_neg_integer(),
+                         day => non_neg_integer(),
+                         hour => non_neg_integer(),
+                         min => non_neg_integer(),
+                         sec => non_neg_integer(),
+                         nano => integer() %% fraction of sec, range -1e9 .. 1e9
+                        }.
 
--export_type([nav_pvt/0, nav_sat/0, nav_posllh/0, nav_sol/0, fix_type/0]).
+-export_type([nav_pvt/0, nav_sat/0, nav_posllh/0, nav_sol/0, nav_timeutc/0, fix_type/0]).
 
 
 -record(state, {
@@ -398,6 +408,20 @@ parse(?NAV, ?POSLLH, <<_ITOW:?U4, Longitude:?I4, Latitude:?I4, _Height:?I4, _Hei
 parse(?NAV, ?SOL, <<_ITOW:?U4, _FTOW:?I4, _Week:?I2, GPSFix:?U1, _/binary>>) ->
     %io:format("SOL ~p~n", [GPSFix]),
     {nav_sol, GPSFix};
+%% UBX-NAV-TIMEUTC
+parse(?NAV, ?TIMEUTC, <<_ITOW:?U4, _TAcc:?U4, Nano:?I4, Year:?U2, Month:?U1, Day:?U1, Hour:?U1, Min:?U1, Sec:?U1, Valid:?X1>>) ->
+    io:format("Time UTC: Year ~p Month ~p Day ~p Hour ~p Min ~p Sec ~p Nano ~p~n", [Year, Month, Day, Hour, Min, Sec, Nano]),
+    <<UTCStandard:4/integer-unsigned-big, _:1/integer, ValidUTC:1/integer, ValidWKN:1/integer, ValidTOW:1/integer>> = <<Valid:8/integer-big>>,
+    io:format("          UTCStandard ~p ValidUTC ~p ValidWKN ~p ValidTOW ~p~n", [UTCStandard, ValidUTC, ValidWKN, ValidTOW]),
+    {nav_timeutc, #{
+                    year => Year,
+                    month => Month,
+                    day => Day,
+                    hour => Hour,
+                    min => Min,
+                    sec => Sec,
+                    nano => Nano
+                   }};
 %% UBX-MON-VER
 parse(?MON, ?VER, <<SWVersion:30/binary, HWVersion:10/binary, Tail/binary>>) ->
     SW = hd(binary:split(SWVersion, <<0>>)),
@@ -496,6 +520,7 @@ resolve(nav_pvt) -> {?NAV, ?PVT};
 resolve(nav_sol) -> {?NAV, ?SOL};
 resolve(nav_sat) -> {?NAV, ?SAT};
 resolve(nav_posllh) -> {?NAV, ?POSLLH};
+resolve(nav_timeutc) -> {?NAV, ?TIMEUTC};
 resolve(mon_ver) -> {?MON, ?VER};
 resolve(mon_hw) -> {?MON, ?HW};
 resolve(cfg_port) -> {?CFG, ?PRT};
@@ -506,6 +531,7 @@ resolve(?NAV, ?PVT) -> nav_pvt;
 resolve(?NAV, ?SOL) -> nav_sol;
 resolve(?NAV, ?SAT) -> nav_sat;
 resolve(?NAV, ?POSLLH) -> nav_posllh;
+resolve(?NAV, ?TIMEUTC) -> nav_timeutc;
 resolve(?MON, ?VER) -> mon_ver;
 resolve(?MON, ?HW) -> mon_hw;
 resolve(?CFG, ?PRT) -> cfg_port;


### PR DESCRIPTION
```
# erl -pa lib/*/ebin
Erlang/OTP 21 [erts-10.1] [source] [smp:2:2] [ds:2:2:10] [async-threads:1]

Eshell V10.1  (abort with ^G)
1> {ok, Pid} = ubx:start_link("spidev1.0", 68, [], self()).
Sending b5 62 6 13 4 0 0 0 f0 39 46 e6
Sending b5 62 6 0 14 0 4 0 c1 0 0 0 0 0 0 0 0 0 1 0 1 0 0 0 0 0 e1 38
Sending b5 62 6 31 20 0 0 1 0 0 0 0 0 0 1 0 0 0 0 12 7a 0 0 0 0 0 0 0 0 0 0 0 0 0 6f 8 0 0 5c c0
Sending b5 62 6 9 d 0 0 0 0 0 ff ff 0 0 0 0 0 0 17 31 bf
error timeout
{ok,<0.78.0>}
error timeout
error timeout
2> ubx:poll_message(Pid, nav_timeutc).
Sending b5 62 1 21 0 0 22 67
Time UTC: Year 2015 Month 10 Day 18 Hour 0 Min 46 Sec 19 TAcc 4294967295 Nano 0
          UTCStandard 15 ValidUTC 0 ValidWKN 0 ValidTOW 0
{ok,{nav_timeutc,#{datetime => {{2015,10,18},{0,46,19}},
                   nano => 0,t_acc => 4294967295,utc_std => 15,valid_tow => 0,
                   valid_utc => 0,valid_wkn => 0}}}
```