### PR TITLE
Add function for initial time assistance

### DIFF
--- a/src/ubx.erl
+++ b/src/ubx.erl
@@ -24,6 +24,7 @@
 -define(CFG, 16#06).
 -define(TIM, 16#0d).
 -define(NAV, 16#01).
+-define(MGA_INI, 16#13).
 
 %% message IDs
 -define(TM2, 16#03).
@@ -40,6 +41,7 @@
 -define(TP5, 16#31).
 -define(ANT, 16#13).
 -define(TIMEUTC, 16#21).
+-define(TIME_UTC, 16#40).
 
 
 -type fix_type() :: non_neg_integer(). %% gps fix type
@@ -92,7 +94,7 @@
          }).
 
 -export([start_link/4, enable_message/3, disable_message/2, fix_type/1, stop/2,
-         poll_message/2, poll_message/3, parse/1]).
+         poll_message/2, poll_message/3, set_time_utc/2, parse/1]).
 
 -export([init/1, handle_info/2, handle_cast/2, handle_call/3]).
 
@@ -103,7 +105,7 @@ enable_message(Pid, Msg, Frequency) ->
     {MsgClass, MsgID} = resolve(Msg),
     gen_server:call(Pid, {enable_message, MsgClass, MsgID, Frequency}).
 
-disable_message(Pid,Msg) ->
+disable_message(Pid, Msg) ->
     {MsgClass, MsgID} = resolve(Msg),
     gen_server:call(Pid, {enable_message, MsgClass, MsgID, 0}).
 
@@ -114,6 +116,11 @@ poll_message(Pid, Msg) ->
 poll_message(Pid, Msg, Payload) ->
     {MsgClass, MsgID} = resolve(Msg),
     gen_server:call(Pid, {poll_message, MsgClass, MsgID, Payload}).
+
+set_time_utc(Pid, DateTime) ->
+    MsgClass = ?MGA_INI,
+    MsgID = ?TIME_UTC,
+    gen_server:call(Pid, {send_message, MsgClass, MsgID, DateTime}).
 
 stop(Pid, Reason) ->
     gen_server:stop(Pid, Reason, infinity).
@@ -265,6 +272,27 @@ handle_call({poll_message, MsgClass, MsgID, Payload}, From, State) ->
             {noreply, register_poll(Msg, From, State)};
         _ ->
             {noreply, {error, busy}, State}
+    end;
+
+handle_call({send_message, ?MGA_INI, ?TIME_UTC, DateTime}, _From, State) ->
+    case DateTime of
+        {{Year, Month, Day}, {Hour, Minute, Second}} ->
+            Type = 16#10,
+            Version = 16#00,
+            Source = 0, %% 0: none, i.e. on receipt of message (will be inaccurate!)
+            Fall = 0, %% use falling edge of EXTINT pulse (default rising) - only if source is EXTINT
+            Last = 0, %% use last EXTINT pulse (default next pulse) - only if source is EXTINT
+            Ref = <<Source:4/integer-unsigned-big, Fall:1/integer, Last:1/integer>>,
+            LeapSecs = -128, %% number of leap seconds since 1980 (-128 if unknown)
+            Reserved1 = <<0>>,
+            Nanosecs = 0,
+            TAccS = 0, %% seconds part of time accuracy
+            Reserved2 = <<0, 0>>,
+            TAccNs = 500000000, %% nanoseconds part of time accuracy
+            send(State, frame(?MGA_INI, ?TIME_UTC, <<Type:?U1, Version:?U1, Ref:?X1, LeapSecs:?I1, Year:?U2, Month:?U1, Day:?U1, Hour:?U1, Minute:?U1, Second:?U1, Reserved1/binary, Nanosecs:?U4, TAccS:?U2, Reserved2/binary, TAccNs:?U4>>)),
+            {noreply, State};
+        _ ->
+            {noreply, {error, invalid_datetime}, State}
     end;
 handle_call(Msg, _From, State) ->
     {reply, {unknown_call, Msg}, State}.

--- a/src/ubx.erl
+++ b/src/ubx.erl
@@ -118,9 +118,7 @@ poll_message(Pid, Msg, Payload) ->
     gen_server:call(Pid, {poll_message, MsgClass, MsgID, Payload}).
 
 set_time_utc(Pid, DateTime) ->
-    MsgClass = ?MGA_INI,
-    MsgID = ?TIME_UTC,
-    gen_server:call(Pid, {send_message, MsgClass, MsgID, DateTime}).
+    gen_server:call(Pid, {set_time_utc, DateTime}).
 
 stop(Pid, Reason) ->
     gen_server:stop(Pid, Reason, infinity).
@@ -274,7 +272,7 @@ handle_call({poll_message, MsgClass, MsgID, Payload}, From, State) ->
             {reply, {error, busy}, State}
     end;
 
-handle_call({send_message, ?MGA_INI, ?TIME_UTC, DateTime}, _From, State) ->
+handle_call({set_time_utc, DateTime}, _From, State) ->
     case DateTime of
         {{Year, Month, Day}, {Hour, Minute, Second}} ->
             Type = 16#10,


### PR DESCRIPTION
```
# erl -pa lib/*/ebin
Erlang/OTP 21 [erts-10.1] [source] [smp:2:2] [ds:2:2:10] [async-threads:1]

Eshell V10.1  (abort with ^G)
1> application:ensure_all_started(ubx).
{ok,[erlang_ale,ubx]}
2> {ok, Pid} = ubx:start_link("spidev1.0", 68, [], self()).
Sending b5 62 6 13 4 0 0 0 f0 39 46 e6
Sending b5 62 6 0 14 0 4 0 c1 0 0 0 0 0 0 0 0 0 1 0 1 0 0 0 0 0 e1 38
Sending b5 62 6 31 20 0 0 1 0 0 0 0 0 0 1 0 0 0 0 12 7a 0 0 0 0 0 0 0 0 0 0 0 0 0 6f 8 0 0 5c c0
Sending b5 62 6 9 d 0 0 0 0 0 ff ff 0 0 0 0 0 0 17 31 bf
{ok,<0.81.0>}
error timeout
error timeout
error timeout
3> ubx:poll_message(Pid, nav_timeutc).
Sending b5 62 1 21 0 0 22 67
Time UTC: Year 2015 Month 10 Day 18 Hour 0 Min 20 Sec 53 TAcc 4294967295 Nano 0
          UTCStandard 15 ValidUTC 0 ValidWKN 0 ValidTOW 0
{ok,{nav_timeutc,#{datetime => {{2015,10,18},{0,20,53}},
                   nano => 0,t_acc => 4294967295,utc_std => 15,valid_tow => 0,
                   valid_utc => 0,valid_wkn => 0}}}
4> ubx:set_time_utc(Pid, {{2019,1,24},{21,37,0}}).
Sending b5 62 13 40 18 0 10 0 0 80 e3 7 1 18 15 25 0 0 0 0 0 0 0 0 0 0 0 65 cd 1d 87 90
ok
5> ubx:poll_message(Pid, nav_timeutc).            
Sending b5 62 1 21 0 0 22 67
Time UTC: Year 2019 Month 1 Day 24 Hour 21 Min 37 Sec 4 TAcc 500004064 Nano 0
          UTCStandard 15 ValidUTC 1 ValidWKN 1 ValidTOW 1
{ok,{nav_timeutc,#{datetime => {{2019,1,24},{21,37,4}},
                   nano => 0,t_acc => 500004064,utc_std => 15,valid_tow => 1,
                   valid_utc => 1,valid_wkn => 1}}}
6>
```