### PR TITLE
Add support for AssistNow Online

### DIFF
--- a/src/ubx.erl
+++ b/src/ubx.erl
@@ -599,13 +599,16 @@ fix_type(Byte) ->
     end.
 
 bin_to_messages(<<>>, Acc) ->
+    io:format("end of messages"),
     lists:reverse(Acc);
 bin_to_messages(<<?HEADER1, ?HEADER2, _Class:?U1, _ID:?U1, Length:?U2, Body:Length/binary, CK_A:?U1, CK_B:?U1, Tail/binary>>, Acc) ->
     case checksum(<<_ID:?U1, _Class:?U1, Length:?U2, Body/binary>>) of
         {CK_A, CK_B} ->
             %% checksum is OK
+            io:format("checksum: ~p", [CK_A]),
             bin_to_messages(Tail,
                 [<<?HEADER1, ?HEADER2, _Class:?U1, _ID:?U1, Length:?U2, Body:Length/binary, CK_A:?U1, CK_B:?U1>>|Acc]);
         _Other ->
+            io:format("dropping message length: ~p", [Length]),
             bin_to_messages(Tail, Acc)
     end.

--- a/src/ubx.erl
+++ b/src/ubx.erl
@@ -599,16 +599,14 @@ fix_type(Byte) ->
     end.
 
 bin_to_messages(<<>>, Acc) ->
-    io:format("end of messages"),
     lists:reverse(Acc);
-bin_to_messages(<<?HEADER1, ?HEADER2, _Class:?U1, _ID:?U1, Length:?U2, Body:Length/binary, CK_A:?U1, CK_B:?U1, Tail/binary>>, Acc) ->
-    case checksum(<<_ID:?U1, _Class:?U1, Length:?U2, Body/binary>>) of
+bin_to_messages(<<?HEADER1, ?HEADER2, ?MGA_INI:?U1, ID:?U1, Length:?U2, Body:Length/binary, CK_A:?U1, CK_B:?U1, Tail/binary>>, Acc) ->
+    case checksum(<<?MGA_INI:?U1, ID:?U1, Length:?U2, Body/binary>>) of
         {CK_A, CK_B} ->
             %% checksum is OK
-            io:format("checksum: ~p", [CK_A]),
             bin_to_messages(Tail,
-                [<<?HEADER1, ?HEADER2, _Class:?U1, _ID:?U1, Length:?U2, Body:Length/binary, CK_A:?U1, CK_B:?U1>>|Acc]);
-        _Other ->
+                [<<?HEADER1, ?HEADER2, ?MGA_INI:?U1, ID:?U1, Length:?U2, Body:Length/binary, CK_A:?U1, CK_B:?U1>>|Acc]);
+        _ ->
             io:format("dropping message length: ~p", [Length]),
             bin_to_messages(Tail, Acc)
     end.

--- a/src/ubx.erl
+++ b/src/ubx.erl
@@ -94,7 +94,7 @@
          }).
 
 -export([start_link/4, enable_message/3, disable_message/2, fix_type/1, stop/2,
-         poll_message/2, poll_message/3, set_time_utc/2, parse/1]).
+         poll_message/2, poll_message/3, set_time_utc/2, parse/1, upload_online_assistance/2]).
 
 -export([init/1, handle_info/2, handle_cast/2, handle_call/3]).
 
@@ -119,6 +119,9 @@ poll_message(Pid, Msg, Payload) ->
 
 set_time_utc(Pid, DateTime) ->
     gen_server:call(Pid, {set_time_utc, DateTime}).
+
+upload_online_assistance(Pid, File) ->
+    gen_server:call(Pid, {upload_online_assistance, File}, infinity).
 
 stop(Pid, Reason) ->
     gen_server:stop(Pid, Reason, infinity).
@@ -293,6 +296,10 @@ handle_call({set_time_utc, DateTime}, _From, State) ->
         _ ->
             {reply, {error, invalid_datetime}, State}
     end;
+handle_call({upload_online_assistance, Filename}, _From, State) ->
+    {ok, Bin} = file:read_file(Filename),
+    send(State, Bin),
+    {reply, ok, State};
 handle_call(Msg, _From, State) ->
     {reply, {unknown_call, Msg}, State}.
 


### PR DESCRIPTION
So far sending online assistance data to the GPS receiver does not improve TTFF.

```
curl -o online.ubx "http://online-live1.services.u-blox.com/GetOnlineData.ashx?token=<token>;gnss=gps,glo;datatype=eph,alm,aux"
```

```
# erl -pa lib/*/ebin
Erlang/OTP 21 [erts-10.1] [source] [smp:2:2] [ds:2:2:10] [async-threads:1]

Eshell V10.1  (abort with ^G)
1> application:ensure_all_started(ubx).
{ok,[erlang_ale,ubx]}
2> {ok, Pid} = ubx:start_link("spidev1.0", 68, [], self()).
Sending b5 62 6 13 4 0 0 0 f0 39 46 e6
Sending b5 62 6 0 14 0 4 0 c1 0 0 0 0 0 0 0 0 0 1 0 1 0 0 0 0 0 e1 38
Sending b5 62 6 31 20 0 0 1 0 0 0 0 0 0 1 0 0 0 0 12 7a 0 0 0 0 0 0 0 0 0 0 0 0 0 6f 8 0 0 5c c0
Sending b5 62 6 9 d 0 0 0 0 0 ff ff 0 0 0 0 0 0 17 31 bf
{ok,<0.81.0>}
error timeout
error timeout
error timeout
error timeout
error timeout
3> ubx:upload_online_assistance(Pid, "/root/online.ubx").
```
